### PR TITLE
bump pillow to 7.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ itsdangerous==1.1.0
 Jinja2==2.10.1
 line-bot-sdk==1.14.0
 MarkupSafe==1.1.1
-Pillow==6.2.0
+Pillow==7.2.0
 python-dotenv==0.10.3
 requests==2.22.0
 selenium==3.141.0


### PR DESCRIPTION
Bumping version of pillow dependency from 6.2.0 to 7.2.0 since the current version has this few vulnerabilities

CVE-2019-19911 Moderate severity
CVE-2020-5313 Moderate severity
CVE-2020-10379 Moderate severity
CVE-2020-10994 Moderate severity
CVE-2020-10177 Moderate severity

